### PR TITLE
Add cors header as middleware

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ black==19.3b0
 cfgv==2.0.0
 Click==7.0
 Django==2.2.2
+django-cors-headers==3.0.2
 django-filter==2.1.0
 djangorestframework==3.9.4
 entrypoints==0.3
@@ -15,8 +16,8 @@ importlib-resources==1.0.2
 Markdown==3.1.1
 mccabe==0.6.1
 nodeenv==1.3.3
-psycopg2==2.8.3
 pre-commit==1.16.1
+psycopg2==2.8.3
 pycodestyle==2.5.0
 pyflakes==2.1.1
 Pygments==2.4.2

--- a/trackr_server/settings.py
+++ b/trackr_server/settings.py
@@ -27,6 +27,14 @@ DEBUG = True
 
 ALLOWED_HOSTS = []
 
+CORS_ORIGIN_WHITELIST = (
+    "http://localhost",
+    "http://127.0.0.1",
+    "http://localhost:3000",
+    "http://127.0.0.1:3000",
+    "http://api.animaltrackr.com",
+    "https://api.animaltrackr.com",
+)
 
 # Application definition
 
@@ -39,9 +47,11 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "rest_framework",
+    "corsheaders",
 ]
 
 MIDDLEWARE = [
+    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",


### PR DESCRIPTION
(hopefully) fixes cors error when accessing `api.animaltrackr.com` from localhost